### PR TITLE
Make time like 30:08 not 30:8

### DIFF
--- a/log.js
+++ b/log.js
@@ -68,11 +68,10 @@ const color = require("colors"),
     };
 
 function Time() {
-    var date = new Date(),
-        hour = date.getHours(),
-        minute = date.getMinutes(),
-        second = date.getSeconds()
-    return "[" + hour + ":" + minute + ":" + second + "] ";
+d = new Date();
+datetext = d.toTimeString();
+datetext = datetext.split(' ')[0];
+    return "[" + datetext + "] ";
 };
 
 module.exports = log;


### PR DESCRIPTION
If your time unit has 2 digits, and it contains a 0 before the integer, it would ignore the 0 and instead turns it into a 1 digit number. This should fix this.